### PR TITLE
Set C++ standard through target_compile_features

### DIFF
--- a/ati_netcanoem_ft_driver/CMakeLists.txt.ros2
+++ b/ati_netcanoem_ft_driver/CMakeLists.txt.ros2
@@ -20,7 +20,6 @@ set(Eigen3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 include_directories(include src SYSTEM ${Eigen3_INCLUDE_DIRS})
 
 ## Build options
-add_compile_options(-std=c++14)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Werror)
@@ -38,6 +37,7 @@ add_library(${PROJECT_NAME}
             include/${PROJECT_NAME}/ati_netcanoem_ft_driver.hpp
             src/${PROJECT_NAME}/ati_netcanoem_ft_driver.cpp)
 ament_target_dependencies(${PROJECT_NAME} common_robotics_utilities)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
 ## Declare C++ components library
 add_library(${PROJECT_NAME}_components SHARED

--- a/dji_robomaster_ep_driver/CMakeLists.txt.ros2
+++ b/dji_robomaster_ep_driver/CMakeLists.txt.ros2
@@ -23,7 +23,6 @@ set(Eigen3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 include_directories(include src SYSTEM ${Eigen3_INCLUDE_DIRS})
 
 ## Build options
-add_compile_options(-std=c++14)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Werror)
@@ -46,6 +45,7 @@ add_library(${PROJECT_NAME}
             src/${PROJECT_NAME}/joystick_controller_mappings.cpp)
 ament_target_dependencies(${PROJECT_NAME}
   common_robotics_utilities geometry_msgs sensor_msgs)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
 ## Declare C++ components library
 add_library(${PROJECT_NAME}_components SHARED

--- a/robotiq_2_finger_gripper_driver/CMakeLists.txt.ros2
+++ b/robotiq_2_finger_gripper_driver/CMakeLists.txt.ros2
@@ -25,7 +25,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}_msgs
 include_directories(include)
 
 ## Build options
-add_compile_options(-std=c++14)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Werror)
@@ -43,6 +42,7 @@ add_library(${PROJECT_NAME}
             include/${PROJECT_NAME}/robotiq_2_finger_gripper_driver.hpp
             src/${PROJECT_NAME}/robotiq_2_finger_gripper_driver.cpp)
 target_link_libraries(${PROJECT_NAME} modbus)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
 ## Declare ROS C++ components
 add_library(${PROJECT_NAME}_components SHARED src/robotiq_2_finger_gripper_driver_node.ros2.cpp)

--- a/robotiq_3_finger_gripper_driver/CMakeLists.txt.ros2
+++ b/robotiq_3_finger_gripper_driver/CMakeLists.txt.ros2
@@ -27,7 +27,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}_msgs
 include_directories(include)
 
 ## Build options
-add_compile_options(-std=c++14)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Werror)
@@ -46,6 +45,7 @@ add_library(${PROJECT_NAME}
             src/${PROJECT_NAME}/robotiq_3_finger_gripper_driver.cpp)
 ament_target_dependencies(${PROJECT_NAME} common_robotics_utilities)
 target_link_libraries(${PROJECT_NAME} modbus)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
 ## Declare ROS C++ components
 add_library(${PROJECT_NAME}_components SHARED

--- a/robotiq_ft_driver/CMakeLists.txt.ros2
+++ b/robotiq_ft_driver/CMakeLists.txt.ros2
@@ -18,7 +18,6 @@ set(Eigen3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 include_directories(include SYSTEM ${Eigen3_INCLUDE_DIRS})
 
 ## Build options
-add_compile_options(-std=c++14)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Werror)
@@ -36,6 +35,7 @@ add_library(${PROJECT_NAME}
             include/${PROJECT_NAME}/robotiq_ft_driver.hpp
             src/${PROJECT_NAME}/robotiq_ft_driver.cpp)
 target_link_libraries(${PROJECT_NAME} modbus)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
 ## Declare ROS C++ components
 add_library(${PROJECT_NAME}_components SHARED

--- a/schunk_wsg_driver/CMakeLists.txt.ros2
+++ b/schunk_wsg_driver/CMakeLists.txt.ros2
@@ -24,7 +24,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}_msgs
 include_directories(include)
 
 ## Build options
-add_compile_options(-std=c++14)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Werror)
@@ -46,6 +45,7 @@ add_library(${PROJECT_NAME}
             src/${PROJECT_NAME}/schunk_wsg_driver_ethernet.cpp
             src/${PROJECT_NAME}/schunk_wsg_driver_can.cpp)
 ament_target_dependencies(${PROJECT_NAME} common_robotics_utilities)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
 ## Declare ROS C++ components
 add_library(${PROJECT_NAME}_components SHARED


### PR DESCRIPTION
This is required to build with the most recent version of rclcpp, since it uses `std::variant` in a header.
Using `target_compile_features()` allows a target to specify the C++ standard it needs, but it's allowed to be increased if one of it's dependencies requires it. Depending on `rclcpp` will [use cause CMake to choose C++17](https://github.com/ros2/rclcpp/blob/b953bdddf8de213b4a051ecf2d668dad65ff9f89/rclcpp/CMakeLists.txt#L182). Using `add_compile_options()` directly was overriding that logic.