### PR TITLE
Replace ClampValueAndWarn with ClampValue to suppress log spam

### DIFF
--- a/dji_robomaster_ep_driver/src/dji_robomaster_ep_driver/dji_robomaster_ep_driver.cpp
+++ b/dji_robomaster_ep_driver/src/dji_robomaster_ep_driver/dji_robomaster_ep_driver.cpp
@@ -144,14 +144,14 @@ void DJIRobomasterEPInterfaceTCP::CommandVelocity(const Twist& velocity_command)
   const auto clamp_linear_velocity = [] (const double val)
   {
     const double linear_velocity_limit = 3.5;
-    return common_robotics_utilities::utility::ClampValueAndWarn(
+    return common_robotics_utilities::utility::ClampValue(
         val, -linear_velocity_limit, linear_velocity_limit);
   };
 
   const auto clamp_angular_velocity = [] (const double val)
   {
     const double angular_velocity_limit = DegreesToRadians(600.0);
-    return common_robotics_utilities::utility::ClampValueAndWarn(
+    return common_robotics_utilities::utility::ClampValue(
         val, -angular_velocity_limit, angular_velocity_limit);
   };
 

--- a/lightweight_ur_interface/src/ur_minimal_hardware_interface.ros1.cpp
+++ b/lightweight_ur_interface/src/ur_minimal_hardware_interface.ros1.cpp
@@ -29,7 +29,7 @@ using common_robotics_utilities::ros_conversions
           ::EigenIsometry3dToGeometryPoseStamped;
 using common_robotics_utilities::ros_conversions
           ::EigenVector3dToGeometryVector3;
-using common_robotics_utilities::utility::ClampValueAndWarn;
+using common_robotics_utilities::utility::ClampValue;
 using common_robotics_utilities::utility::CollectionsEqual;
 using common_robotics_utilities::utility::GetKeysFromMapLike;
 
@@ -286,8 +286,7 @@ public:
             const double velocity_limit
                 = limits_found_itr->second.MaxVelocity();
             const double limited_velocity
-                = common_robotics_utilities::utility::ClampValueAndWarn(
-                    velocity, -velocity_limit, velocity_limit);
+                = ClampValue(velocity, -velocity_limit, velocity_limit);
             target_velocity[idx] = limited_velocity;
           }
           // If we don't have limits saved, then we don't need to limit
@@ -477,11 +476,9 @@ int main(int argc, char** argv)
       = std::abs(nhp.param(std::string("acceleration_limit_scaling"),
                            DEFAULT_ACCELERATION_LIMIT_SCALING));
   const double real_velocity_limit_scaling
-      = common_robotics_utilities::utility::ClampValueAndWarn(
-          velocity_limit_scaling, 0.0, 1.0);
+      = ClampValue(velocity_limit_scaling, 0.0, 1.0);
   const double real_acceleration_limit_scaling
-      = common_robotics_utilities::utility::ClampValueAndWarn(
-          acceleration_limit_scaling, 0.0, 1.0);
+      = ClampValue(acceleration_limit_scaling, 0.0, 1.0);
   // Joint names in true order
   const std::vector<std::string> ordered_joint_names
       = lightweight_ur_interface::GetOrderedJointNames();

--- a/lightweight_ur_interface/src/ur_position_controller.ros1.cpp
+++ b/lightweight_ur_interface/src/ur_position_controller.ros1.cpp
@@ -25,7 +25,6 @@ namespace lightweight_ur_interface
 {
 using common_robotics_utilities::print::Print;
 using common_robotics_utilities::utility::ClampValue;
-using common_robotics_utilities::utility::ClampValueAndWarn;
 using common_robotics_utilities::math::Add;
 using common_robotics_utilities::math::Sub;
 using common_robotics_utilities::math::Multiply;
@@ -383,9 +382,9 @@ public:
         {
           const double position = found_itr->second;
           const double limited_position
-              = ClampValueAndWarn(position,
-                                  joint_position_limit.first,
-                                  joint_position_limit.second);
+              = ClampValue(position,
+                           joint_position_limit.first,
+                           joint_position_limit.second);
           target_config[idx] = limited_position;
         }
         else
@@ -513,11 +512,9 @@ int main(int argc, char** argv)
       = std::abs(nhp.param(std::string("acceleration_limit_scaling"),
                            DEFAULT_ACCELERATION_LIMIT_SCALING));
   const double real_velocity_limit_scaling
-      = common_robotics_utilities::utility::ClampValueAndWarn(
-          velocity_limit_scaling, 0.0, 1.0);
+      = ClampValue(velocity_limit_scaling, 0.0, 1.0);
   const double real_acceleration_limit_scaling
-      = common_robotics_utilities::utility::ClampValueAndWarn(
-          acceleration_limit_scaling, 0.0, 1.0);
+      = ClampValue(acceleration_limit_scaling, 0.0, 1.0);
   const double base_kp
       = std::abs(nhp.param(std::string("base_kp"), DEFAULT_BASE_KP));
   const double base_kd

--- a/lightweight_ur_interface/src/ur_script_hardware_interface.ros1.cpp
+++ b/lightweight_ur_interface/src/ur_script_hardware_interface.ros1.cpp
@@ -31,7 +31,7 @@ using common_robotics_utilities::ros_conversions
           ::EigenIsometry3dToGeometryPoseStamped;
 using common_robotics_utilities::ros_conversions
           ::EigenVector3dToGeometryVector3;
-using common_robotics_utilities::utility::ClampValueAndWarn;
+using common_robotics_utilities::utility::ClampValue;
 using common_robotics_utilities::serialization::SerializeNetworkMemcpyable;
 using common_robotics_utilities::utility::CollectionsEqual;
 using common_robotics_utilities::utility::GetKeysFromMapLike;
@@ -694,7 +694,7 @@ public:
             const double velocity_limit
                 = limits_found_itr->second.MaxVelocity();
             const double limited_velocity
-                = ClampValueAndWarn(velocity, -velocity_limit, velocity_limit);
+                = ClampValue(velocity, -velocity_limit, velocity_limit);
             target_velocity[idx] = limited_velocity;
           }
           // If we don't have limits saved, then we don't need to limit
@@ -890,11 +890,9 @@ int main(int argc, char** argv)
       = std::abs(nhp.param(std::string("acceleration_limit_scaling"),
                            DEFAULT_ACCELERATION_LIMIT_SCALING));
   const double real_velocity_limit_scaling
-      = common_robotics_utilities::utility::ClampValueAndWarn(
-          velocity_limit_scaling, 0.0, 1.0);
+      = ClampValue(velocity_limit_scaling, 0.0, 1.0);
   const double real_acceleration_limit_scaling
-      = common_robotics_utilities::utility::ClampValueAndWarn(
-          acceleration_limit_scaling, 0.0, 1.0);
+      = ClampValue(acceleration_limit_scaling, 0.0, 1.0);
   // Joint names in true order
   const std::vector<std::string> ordered_joint_names
       = lightweight_ur_interface::GetOrderedJointNames();

--- a/lightweight_ur_interface/src/ur_trajectory_controller.ros1.cpp
+++ b/lightweight_ur_interface/src/ur_trajectory_controller.ros1.cpp
@@ -26,7 +26,6 @@ namespace lightweight_ur_interface
 {
 using common_robotics_utilities::print::Print;
 using common_robotics_utilities::utility::ClampValue;
-using common_robotics_utilities::utility::ClampValueAndWarn;
 using common_robotics_utilities::math::Add;
 using common_robotics_utilities::math::Sub;
 using common_robotics_utilities::math::Multiply;
@@ -479,9 +478,9 @@ public:
           {
             const double position = found_itr->second;
             const double limited_position
-                = ClampValueAndWarn(position,
-                                    joint_position_limit.first,
-                                    joint_position_limit.second);
+                = ClampValue(position,
+                             joint_position_limit.first,
+                             joint_position_limit.second);
             ordered_trajectory_point(static_cast<ssize_t>(idx))
                 = limited_position;
           }
@@ -637,11 +636,9 @@ int main(int argc, char** argv)
       = std::abs(nhp.param(std::string("acceleration_limit_scaling"),
                            DEFAULT_ACCELERATION_LIMIT_SCALING));
   const double real_velocity_limit_scaling
-      = common_robotics_utilities::utility::ClampValueAndWarn(
-          velocity_limit_scaling, 0.0, 1.0);
+      = ClampValue(velocity_limit_scaling, 0.0, 1.0);
   const double real_acceleration_limit_scaling
-      = common_robotics_utilities::utility::ClampValueAndWarn(
-          acceleration_limit_scaling, 0.0, 1.0);
+      = ClampValue(acceleration_limit_scaling, 0.0, 1.0);
   const double base_kp
       = std::abs(nhp.param(std::string("base_kp"), DEFAULT_BASE_KP));
   const double base_kd


### PR DESCRIPTION
Existing uses of `ClampValueAndWarn` offered little practical benefit, and `ClampValueAndWarn` is being replaced in `common_robotics_utilities` with more a more flexible `ClampValueAndLog` function.