### PR TITLE
Fix missing rosidl_default_generators dep

### DIFF
--- a/schunk_wsg_driver/CMakeLists.txt.ros2
+++ b/schunk_wsg_driver/CMakeLists.txt.ros2
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 project(schunk_wsg_driver)
 
 find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
 find_package(common_robotics_utilities REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)


### PR DESCRIPTION
Found when building on 24.04/Jazzy